### PR TITLE
ci: create github workflow to test on Ubuntu, Windows, Mac OS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,64 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  default-build:
+    name: Test
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: actions/checkout@v5
+      - run: rustup component add rustfmt clippy
+
+      # dependencies for wxWidgets (see installation instructions and github
+      # workflow of https://github.com/allendang/wxdragon)
+      - name: Install deps
+        if: runner.os == 'Linux'
+        run: sudo apt-get update && sudo apt-get install -y libgtk-3-dev libpng-dev libjpeg-dev libgl1-mesa-dev libglu1-mesa-dev libxkbcommon-dev libexpat1-dev libtiff-dev libwebkit2gtk-4.1-dev libxtst-dev
+
+      - name: Cargo cache
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+
+      - name: build
+        run: cargo build
+
+      - name: tests
+        run: cargo test --all-features --verbose
+
+      - name: clippy
+        run: cargo clippy --all-features -- -D warnings
+
+      - name: check formatting
+        run: cargo fmt --all -- --check
+
+  docs:
+    name: Documentation
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Build documentation
+        run: cargo doc --all-features --no-deps

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,6 +57,12 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
+      # dependencies for wxWidgets (see installation instructions and github
+      # workflow of https://github.com/allendang/wxdragon)
+      - name: Install deps
+        if: runner.os == 'Linux'
+        run: sudo apt-get update && sudo apt-get install -y libgtk-3-dev libpng-dev libjpeg-dev libgl1-mesa-dev libglu1-mesa-dev libxkbcommon-dev libexpat1-dev libtiff-dev libwebkit2gtk-4.1-dev libxtst-dev
+
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,11 +27,10 @@ jobs:
       - run: rustup component add rustfmt clippy
 
       # dependencies for wxWidgets (see installation instructions and github
-      # workflow of https://github.com/allendang/wxdragon); only xvfb is
-      # specific to this setup
+      # workflow of https://github.com/allendang/wxdragon)
       - name: Install deps
         if: runner.os == 'Linux'
-        run: sudo apt-get update && sudo apt-get install -y libgtk-3-dev libpng-dev libjpeg-dev libgl1-mesa-dev libglu1-mesa-dev libxkbcommon-dev libexpat1-dev libtiff-dev libwebkit2gtk-4.1-dev libxtst-dev xvfb
+        run: sudo apt-get update && sudo apt-get install -y libgtk-3-dev libpng-dev libjpeg-dev libgl1-mesa-dev libglu1-mesa-dev libxkbcommon-dev libexpat1-dev libtiff-dev libwebkit2gtk-4.1-dev libxtst-dev
 
       - name: Cargo cache
         uses: actions/cache@v4
@@ -48,14 +47,16 @@ jobs:
         # skip main doc test because it opens a window
       - run: sed -i 's/```rust/```no_run/g' src/lib.rs
 
-      - name: tests
-        run: xvfb-run cargo test --all-features --verbose
-
       - name: clippy
         run: cargo clippy --all-features -- -D warnings
 
       - name: check formatting
         run: cargo fmt --all -- --check
+
+      - name: headless tests
+        uses: coactions/setup-xvfb@v1
+        with:
+          run: cargo test --all-features --verbose
 
   docs:
     name: Documentation

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest, windows-latest]
+        # os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,8 @@ jobs:
     steps:
       - uses: dtolnay/rust-toolchain@stable
       - uses: actions/checkout@v5
+        with:
+          - lfs: true
       - run: rustup component add rustfmt clippy
 
       # dependencies for wxWidgets (see installation instructions and github

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,12 +51,28 @@ jobs:
       - name: check formatting
         run: cargo fmt --all -- --check
 
-      # - name: headless tests
-      #   uses: coactions/setup-xvfb@v1
-      #   with:
-      #     # skip main doc test because it opens a window
-      #     # run: cargo test --all-features --verbose
-      #     run: cargo test --all-features --verbose --lib --tests
+      - name: headless tests
+        if: runner.os == 'Linux'
+        uses: coactions/setup-xvfb@v1
+        with:
+          # skip main doc test because it opens a window
+          # run: cargo test --all-features --verbose
+          run: cargo test --all-features --verbose --lib --tests
+
+      - name: headless tests
+        if: runner.os == 'Windows'
+        # skip main doc test because it opens a window
+        # run: cargo test --all-features --verbose
+        run: cargo test --all-features --verbose --lib --tests
+
+      - name: upload test outputs
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: tests-outputs
+          path: |
+            tests/outputs/
+          retention-days: 7
 
   docs:
     name: Documentation

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,9 @@ jobs:
       - name: build
         run: cargo build
 
+        # skip main doc test because it opens a window
+      - run: sed -i 's/```rust/```no_run/g' src/lib.rs
+
       - name: tests
         run: xvfb-run cargo test --all-features --verbose
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,9 +45,6 @@ jobs:
       - name: build
         run: cargo build
 
-        # skip main doc test because it opens a window
-      - run: sed -i 's/```rust/```no_run/g' src/lib.rs
-
       - name: clippy
         run: cargo clippy --all-features -- -D warnings
 
@@ -57,7 +54,9 @@ jobs:
       - name: headless tests
         uses: coactions/setup-xvfb@v1
         with:
-          run: cargo test --all-features --verbose
+          # skip main doc test because it opens a window
+          # run: cargo test --all-features --verbose
+          run: cargo test --all-features --verbose --lib --tests
 
   docs:
     name: Documentation

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,12 +51,12 @@ jobs:
       - name: check formatting
         run: cargo fmt --all -- --check
 
-      - name: headless tests
-        uses: coactions/setup-xvfb@v1
-        with:
-          # skip main doc test because it opens a window
-          # run: cargo test --all-features --verbose
-          run: cargo test --all-features --verbose --lib --tests
+      # - name: headless tests
+      #   uses: coactions/setup-xvfb@v1
+      #   with:
+      #     # skip main doc test because it opens a window
+      #     # run: cargo test --all-features --verbose
+      #     run: cargo test --all-features --verbose --lib --tests
 
   docs:
     name: Documentation

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,10 +25,11 @@ jobs:
       - run: rustup component add rustfmt clippy
 
       # dependencies for wxWidgets (see installation instructions and github
-      # workflow of https://github.com/allendang/wxdragon)
+      # workflow of https://github.com/allendang/wxdragon); only xvfb is
+      # specific to this setup
       - name: Install deps
         if: runner.os == 'Linux'
-        run: sudo apt-get update && sudo apt-get install -y libgtk-3-dev libpng-dev libjpeg-dev libgl1-mesa-dev libglu1-mesa-dev libxkbcommon-dev libexpat1-dev libtiff-dev libwebkit2gtk-4.1-dev libxtst-dev
+        run: sudo apt-get update && sudo apt-get install -y libgtk-3-dev libpng-dev libjpeg-dev libgl1-mesa-dev libglu1-mesa-dev libxkbcommon-dev libexpat1-dev libtiff-dev libwebkit2gtk-4.1-dev libxtst-dev xvfb
 
       - name: Cargo cache
         uses: actions/cache@v4
@@ -43,7 +44,7 @@ jobs:
         run: cargo build
 
       - name: tests
-        run: cargo test --all-features --verbose
+        run: xvfb-run cargo test --all-features --verbose
 
       - name: clippy
         run: cargo clippy --all-features -- -D warnings

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
       - uses: actions/checkout@v5
         with:
-          - lfs: true
+          lfs: true
       - run: rustup component add rustfmt clippy
 
       # dependencies for wxWidgets (see installation instructions and github

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .aider*
 target
+/tests/outputs

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -98,22 +98,20 @@
 //!        }
 //!    }
 //!
-//!    fn main() {
-//!        let _ = wxdragon::main(|_| {
-//!            let frame = wx::Frame::builder()
-//!                .with_title("Getting started")
-//!                // with this, wx produces a canvas of size 800 x 600
-//!                .with_size(wx::Size::new(852, 689))
-//!                .build();
+//!    let _ = wxdragon::main(|_| {
+//!        let frame = wx::Frame::builder()
+//!            .with_title("Getting started")
+//!            // with this, wx produces a canvas of size 800 x 600
+//!            .with_size(wx::Size::new(852, 689))
+//!            .build();
 //!
-//!            let drawing_panel = DrawingPanel::new(&frame);
+//!        let drawing_panel = DrawingPanel::new(&frame);
 //!
-//!            // Initial paint
-//!            drawing_panel.refresh(true, None);
+//!        // Initial paint
+//!        drawing_panel.refresh(true, None);
 //!
-//!            frame.show(true);
-//!        });
-//!    }
+//!        frame.show(true);
+//!    });
 //!    ```
 //!
 //!    You can find more details in the examples for how to integrate a plot in

--- a/tests/3d_plot.rs
+++ b/tests/3d_plot.rs
@@ -10,7 +10,7 @@ use test_utils::run_plotters_image_test;
 
 #[test]
 fn test_3d_plot() -> anyhow::Result<()> {
-    run_plotters_image_test(1024, 768, "tests/3d_plot", draw_3d_plot)
+    run_plotters_image_test(1024, 768, "tests/3d_plot.png", draw_3d_plot)
 }
 
 fn draw_3d_plot<C: DeviceContext>(backend: WxBackend<C>) -> anyhow::Result<()> {

--- a/tests/chart.rs
+++ b/tests/chart.rs
@@ -12,7 +12,7 @@ use test_utils::run_plotters_image_test;
 
 #[test]
 fn test_chart() -> anyhow::Result<()> {
-    run_plotters_image_test(1024, 768, "tests/chart", draw_chart)
+    run_plotters_image_test(1024, 768, "tests/chart.png", draw_chart)
 }
 
 fn draw_chart<C: DeviceContext>(backend: WxBackend<C>) -> anyhow::Result<()> {

--- a/tests/full_palette.rs
+++ b/tests/full_palette.rs
@@ -12,7 +12,12 @@ use test_utils::run_plotters_image_test;
 
 #[test]
 fn test_full_palette() -> anyhow::Result<()> {
-    run_plotters_image_test(2000, 850, "tests/full_palette", draw_full_palette)
+    run_plotters_image_test(
+        2000,
+        850,
+        "tests/full_palette.png",
+        draw_full_palette,
+    )
 }
 fn draw_full_palette<C: DeviceContext>(
     backend: WxBackend<C>,

--- a/tests/mandelbrot.rs
+++ b/tests/mandelbrot.rs
@@ -15,7 +15,7 @@ use test_utils::run_plotters_image_test;
 
 #[test]
 fn test_mandelbrot() -> Result<()> {
-    run_plotters_image_test(800, 600, "tests/mandelbrot", draw_mandelbrot)
+    run_plotters_image_test(800, 600, "tests/mandelbrot.png", draw_mandelbrot)
 }
 
 fn draw_mandelbrot<C: DeviceContext>(backend: WxBackend<C>) -> Result<()> {

--- a/tests/test_utils.rs
+++ b/tests/test_utils.rs
@@ -2,6 +2,8 @@
 
 use std::fs;
 use std::io;
+use std::path::Path;
+use std::path::PathBuf;
 use std::process;
 
 use anyhow::{Context, Result};
@@ -14,15 +16,18 @@ use wxdragon::{self as wx};
 ///
 /// This function sets up a wxWidgets `MemoryDC`, draws on it using the
 /// provided `draw_fn`, then compares the resulting bitmap with a reference
-/// image loaded from `{path_root}.png`. If the images do not match, the test
+/// image loaded from `{reference_png}`. If the images do not match, the test
 /// will fail.
+///
+/// In case of image mismatch, the actual producted image i saved in
+/// subdirectory `/outputs/` of the directory containing `{reference_png}`.
 ///
 /// # Arguments
 ///
 /// * `width`: width of the drawing area.
 /// * `height`: height of the drawing area.
-/// * `path_root`: used to build the path `"{path_root}.png"` to the reference
-///   PNG image for non-regression comparison.
+/// * `reference_png`: path to the reference PNG image for non-regression
+///   comparison.
 /// * `draw_fn`: closure that performs the drawing operations.
 ///
 /// # Returns
@@ -33,14 +38,26 @@ use wxdragon::{self as wx};
 pub fn run_plotters_image_test<F>(
     width: u32,
     height: u32,
-    path_root: &str,
+    reference_png: impl Into<PathBuf>,
     draw_fn: F,
 ) -> Result<()>
 where
     F: FnOnce(WxBackend<wx::MemoryDC>) -> Result<()> + Send + 'static,
 {
-    let reference_png = format!("{path_root}.png");
-    let actual_png = format!("{path_root}_actual.png"); // saved if mismatch
+    let reference_png = reference_png.into();
+    let (output_dir, actual_png) = {
+        let output_dir = reference_png
+            .parent()
+            .unwrap_or_else(|| Path::new(""))
+            .join("outputs");
+        let actual_png = output_dir.join(
+            reference_png
+                .file_name()
+                .context("Invalid reference_png path: missing filename")?,
+        );
+        (output_dir, actual_png)
+    };
+
     let _ = wx::main(move |_| {
         let result = (|| -> Result<()> {
             // setup the backend with an empty bitmap
@@ -69,27 +86,36 @@ where
             let expected = image::load(
                 io::BufReader::new(
                     fs::File::open(&reference_png).with_context(|| {
-                        format!("failed to open {reference_png}")
+                        format!("failed to open {}", reference_png.display())
                     })?,
                 ),
                 image::ImageFormat::Png,
             )
-            .with_context(|| "failed to load {reference_png}")?;
+            .with_context(|| {
+                format!("failed to load {}", reference_png.display())
+            })?;
+
+            // save actual image for later comparison in case of failure
+            fs::create_dir_all(&output_dir).context(format!(
+                "failed to create directory {}",
+                output_dir.display()
+            ))?;
+            image
+                .save(&actual_png)
+                .context(format!("failed to save {}", actual_png.display()))?;
+
             if expected == image::DynamicImage::ImageRgba8(image.clone()) {
                 Ok(())
             } else {
-                // regenerate expected image by uncommenting this and
-                // commenting the non-regression part
-                image
-                    .save(&actual_png)
-                    .context("failed to save {actual_png}")?;
                 let message = format!(
                     "ERROR: image mismatch.
 Compare the following two files manually, then \
 update the reference image if needed.
-  reference image: {reference_png}
-  actual image   : {actual_png}
-"
+  reference image: {}
+  actual image   : {}
+",
+                    reference_png.display(),
+                    actual_png.display()
                 );
                 anyhow::bail!(message)
             }


### PR DESCRIPTION
This pull request creates a basic github workflow to build and check the crate:
* run cargo build, cargo clippy, cargo fmt on following targets: Ubuntu, WIndows
* build documentation

Note: unit tests cannot be run because they need to call into the main loop of `wxWidgets`, which I did not yet manage to run in a headless CI environment.